### PR TITLE
Fix #26 - Screenshot not taken in silent mode

### DIFF
--- a/src/ExceptionReporter/Views/ExceptionReportView.cs
+++ b/src/ExceptionReporter/Views/ExceptionReportView.cs
@@ -91,17 +91,6 @@ namespace ExceptionReporting.Views
 			txtUserExplanation.Font = new Font(txtUserExplanation.Font.FontFamily, reportInfo.UserExplanationFontSize);
 			lblContactCompany.Text = string.Format("If this problem persists, please contact {0} support.", reportInfo.CompanyName);
 			btnSimpleEmail.Text = string.Format("E-mail {0}", reportInfo.CompanyName);
-
-			if (reportInfo.TakeScreenshot)
-			{
-				try
-				{
-					reportInfo.ScreenshotImage = ScreenshotTaker.TakeScreenShot();
-				}
-				catch { }
-				// not too concerned about the specifics at the moment, just that an exception here doesn't prevent the entire mechansim from working
-				// specifically, if we are raising this exception as the result of an out-of-memory exception, we have little chance of a screenshot succeeding
-			}
 		}
 
 		private void RemoveEmailButton()

--- a/src/Test.ExceptionReporter/Attacher_Tests.cs
+++ b/src/Test.ExceptionReporter/Attacher_Tests.cs
@@ -117,6 +117,16 @@ namespace ExceptionReporting.Tests
 
 			_iattach.Verify((a) => a.Attach("file1.zip"), Times.Once());
 			_iattach.Verify((a) => a.Attach("attach.zip"), Times.Once());
-		}
-	}
+	    }
+
+	    [Test]
+	    public void Should_Make_Screenshot_In_Silent_Mode__Issue_26()
+	    {
+	        var attacher = new Attacher(new ExceptionReportInfo { TakeScreenshot = true });
+
+	        attacher.AttachFiles(_iattach.Object);
+
+	        Assert.IsTrue(attacher.Config.ScreenshotAvailable);
+	    }
+    }
 }


### PR DESCRIPTION
When the `ExceptionRepoerter.Send(params Exception[] exceptions)` method invoked directly and the `ExceptionReportingInfo.TakeScreenshot` set to `true` the crash report not included the screenshot.