### PR TITLE
#53 click on Save button save an archive with FilesToAttach instead of .txt

### DIFF
--- a/src/ExceptionReporting/Core/IZipReportService.cs
+++ b/src/ExceptionReporting/Core/IZipReportService.cs
@@ -1,0 +1,24 @@
+namespace ExceptionReporting.Core
+{
+	internal interface IZipReportService
+	{
+		/// <summary>
+		/// Create Zip file
+		/// filepath = %TEMP% + ExceptionReportInfo.AttachmentFilename
+		/// </summary>
+		/// <returns>
+		/// Path to zip file.
+		/// Empty if not saved.
+		/// </returns>
+		string CreateZipReport(ExceptionReportInfo reportInfo);
+
+		/// <summary>
+		/// Create Zip file
+		/// </summary>
+		/// <returns>
+		/// Path to zip file.
+		/// Empty if not saved.
+		/// </returns>
+		string CreateZipReport(ExceptionReportInfo reportInfo, string filepath);
+	}
+}

--- a/src/ExceptionReporting/Core/IZipReportService.cs
+++ b/src/ExceptionReporting/Core/IZipReportService.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace ExceptionReporting.Core
 {
 	internal interface IZipReportService
@@ -10,7 +12,7 @@ namespace ExceptionReporting.Core
 		/// Path to zip file.
 		/// Empty if not saved.
 		/// </returns>
-		string CreateZipReport(ExceptionReportInfo reportInfo);
+		string CreateZipReport(ExceptionReportInfo reportInfo, IEnumerable<string> additionalFilesToAttach);
 
 		/// <summary>
 		/// Create Zip file
@@ -19,6 +21,6 @@ namespace ExceptionReporting.Core
 		/// Path to zip file.
 		/// Empty if not saved.
 		/// </returns>
-		string CreateZipReport(ExceptionReportInfo reportInfo, string filepath);
+		string CreateZipReport(ExceptionReportInfo reportInfo, string filepath, IEnumerable<string> additionalFilesToAttach);
 	}
 }

--- a/src/ExceptionReporting/Core/ZipReportService.cs
+++ b/src/ExceptionReporting/Core/ZipReportService.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using ExceptionReporting.Mail;
+
+namespace ExceptionReporting.Core
+{
+	internal class ZipReportService : IZipReportService
+	{
+		private IZipper Zipper { get; } = new Zipper();
+		private IScreenshotTaker ScreenshotTaker { get; } = new ScreenshotTaker();
+
+		public ZipReportService()
+		{
+			Zipper = new Zipper();
+			ScreenshotTaker = new ScreenshotTaker();
+		}
+
+		public ZipReportService(IZipper zipper, IScreenshotTaker screenshotTaker)
+		{
+			Zipper = zipper;
+			ScreenshotTaker = screenshotTaker;
+		}
+
+		public string CreateZipReport(ExceptionReportInfo reportInfo)
+		{
+			string zipFilePath = Path.Combine(Path.GetTempPath(), reportInfo.AttachmentFilename);
+			return CreateZipReport(reportInfo, zipFilePath);
+		}
+
+		public string CreateZipReport(ExceptionReportInfo reportInfo, string zipFilePath)
+		{
+			if (string.IsNullOrWhiteSpace(zipFilePath)) return string.Empty;
+			if (File.Exists(zipFilePath)) File.Delete(zipFilePath);
+
+			var files = new List<string>();
+			if (reportInfo.FilesToAttach.Length > 0) files.AddRange(reportInfo.FilesToAttach);
+			try
+			{
+				if (reportInfo.TakeScreenshot) files.Add(ScreenshotTaker.TakeScreenShot());
+			}
+			catch { /* ignored */ }
+
+			var filesThatExist = files.Where(f => File.Exists(f)).ToList();
+			var filesToZip = filesThatExist;
+			if (filesToZip.Any())
+				Zipper.Zip(zipFilePath, filesToZip);
+			else
+				return string.Empty;
+
+			return zipFilePath;
+		}
+	}
+}

--- a/src/ExceptionReporting/MVP/Presenters/ExceptionReportPresenter.cs
+++ b/src/ExceptionReporting/MVP/Presenters/ExceptionReportPresenter.cs
@@ -81,8 +81,9 @@ namespace ExceptionReporting.MVP.Presenters
 			}
 			else
 			{
-				var zipReport = new ZipReportService(new Zipper(), new ScreenshotTaker());
-				var result = zipReport.CreateZipReport(ReportInfo, zipFilePath);
+				var additionalFilesToAttach = new List<string>(){textReportPath};
+				var zipReport = new ZipReportService(new Zipper(), new ScreenshotTaker(), new FileService());
+				var result = zipReport.CreateZipReport(ReportInfo, zipFilePath, additionalFilesToAttach);
 				if (!File.Exists(result))
 				{
 					//View.ShowError(string.Format("Unable to save file '{0}'", zipFilePath), result.Exception);

--- a/src/ExceptionReporting/MVP/Presenters/ExceptionReportPresenter.cs
+++ b/src/ExceptionReporting/MVP/Presenters/ExceptionReportPresenter.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using ExceptionReporting.Core;
+using ExceptionReporting.Mail;
 using ExceptionReporting.MVP.Views;
 using ExceptionReporting.Network;
 using ExceptionReporting.Properties;
@@ -46,7 +48,7 @@ namespace ExceptionReporting.MVP.Presenters
 		/// Save the exception report to file/disk
 		/// </summary>
 		/// <param name="fileName">the filename to save to</param>
-		public void SaveReportToFile(string fileName)
+		public void SaveTextReportToFile(string fileName)
 		{
 			if (string.IsNullOrEmpty(fileName)) return;
 
@@ -55,8 +57,37 @@ namespace ExceptionReporting.MVP.Presenters
 			
 			if (!result.Saved)
 			{
-				//View.ShowError(string.Format("Unable to save file '{0}'", fileName), result.Exception);
+				//View.ShowError(string.Format("Unable to save file '{0}'", zipFilePath), result.Exception);
 				View.ShowError(Resources.Unable_to_save_file + $" '{fileName}'", result.Exception);
+			}
+		}
+
+		/// <summary>
+		/// Save the exception report to file/disk
+		/// </summary>
+		/// <param name="zipFilePath">the filename to save to</param>
+		public void SaveZipReportToFile(string zipFilePath)
+		{
+			if (string.IsNullOrEmpty(zipFilePath)) return;
+
+			//TODO: select extension by ReportTemplateFormat
+			var textReportPath = Path.Combine(Path.GetTempPath(), @"ExceptionReporter\report.txt");
+			if (!Directory.Exists(textReportPath)) Directory.CreateDirectory(Path.GetDirectoryName(textReportPath));
+			var report = CreateReport();
+			var textFileSaveResult = _fileService.Write(textReportPath, report);
+			if (!textFileSaveResult.Saved)
+			{
+				View.ShowError(Resources.Unable_to_save_file + $" '{textReportPath}'", textFileSaveResult.Exception);
+			}
+			else
+			{
+				var zipReport = new ZipReportService(new Zipper(), new ScreenshotTaker());
+				var result = zipReport.CreateZipReport(ReportInfo, zipFilePath);
+				if (!File.Exists(result))
+				{
+					//View.ShowError(string.Format("Unable to save file '{0}'", zipFilePath), result.Exception);
+					View.ShowError(Resources.Unable_to_save_file + $" '{result}'", new IOException());
+				}
 			}
 		}
 

--- a/src/ExceptionReporting/MVP/Views/ExceptionReportView.cs
+++ b/src/ExceptionReporting/MVP/Views/ExceptionReportView.cs
@@ -360,16 +360,33 @@ namespace ExceptionReporting.MVP.Views
 
 		private void Save_Click(object sender, EventArgs e)
 		{
-			var saveDialog = new SaveFileDialog
+			var saveArchiveToggle = true;
+			if (saveArchiveToggle)
 			{
-				Filter = "Text Files (*.txt)|*.txt|All files (*.*)|*.*",
-				FilterIndex = 1,
-				RestoreDirectory = true
-			};
+				var saveDialog = new SaveFileDialog
+				{
+					Filter = "Archive (*.zip)|*.zip|All files (*.*)|*.*",
+					FilterIndex = 1,
+					RestoreDirectory = true
+				};
+				if (saveDialog.ShowDialog() == DialogResult.OK)
+				{
+					_presenter.SaveZipReportToFile(saveDialog.FileName);
+				}
+			}
+			else
+			{
+				var saveDialog = new SaveFileDialog
+				{
+					Filter = "Text Files (*.txt)|*.txt|All files (*.*)|*.*",
+					FilterIndex = 1,
+					RestoreDirectory = true
+				};
 
-			if (saveDialog.ShowDialog() == DialogResult.OK)
-			{
-				_presenter.SaveReportToFile(saveDialog.FileName);
+				if (saveDialog.ShowDialog() == DialogResult.OK)
+				{
+					_presenter.SaveTextReportToFile(saveDialog.FileName);
+				}
 			}
 		}
 

--- a/src/ExceptionReporting/Mail/Attacher.cs
+++ b/src/ExceptionReporting/Mail/Attacher.cs
@@ -10,7 +10,7 @@ namespace ExceptionReporting.Mail
 		
 		private readonly ExceptionReportInfo _config;
 
-		public IFileService File { private get; set; } = new FileService();
+		public IFileService FileService { private get; set; } = new FileService();
 		public IZipper Zipper { private get; set; } = new Zipper();
 		public IScreenshotTaker ScreenshotTaker { private get; set; } = new ScreenshotTaker();
 
@@ -32,7 +32,7 @@ namespace ExceptionReporting.Mail
 				if (_config.TakeScreenshot) files.Add(ScreenshotTaker.TakeScreenShot());
 			} catch { /* ignored */ }
 
-			var filesThatExist = files.Where(f => File.Exists(f)).ToList();
+			var filesThatExist = files.Where(f => FileService.Exists(f)).ToList();
 
 			// attach external zip files separately - admittedly weak detection using just file extension
 			filesThatExist.Where(f => f.EndsWith(ZIP)).ToList().ForEach(attacher.Attach);
@@ -41,7 +41,7 @@ namespace ExceptionReporting.Mail
 			var filesToZip = filesThatExist.Where(f => !f.EndsWith(ZIP)).ToList();
 			if (filesToZip.Any())
 			{
-				var zipFile = File.TempFile(_config.AttachmentFilename);
+				var zipFile = FileService.TempFile(_config.AttachmentFilename);
 				Zipper.Zip(zipFile, filesToZip);
 				attacher.Attach(zipFile);
 			}

--- a/src/Tests/Attacher_Tests.cs
+++ b/src/Tests/Attacher_Tests.cs
@@ -25,7 +25,7 @@ namespace Tests.ExceptionReporting
 		{
 			var attacher = new Attacher(new ExceptionReportInfo { FilesToAttach = new string[] {} })
 			{
-				File = _file.Object,
+				FileService = _file.Object,
 				Zipper = _zip.Object
 			};
 
@@ -42,7 +42,7 @@ namespace Tests.ExceptionReporting
 
 			var attacher = new Attacher(new ExceptionReportInfo { FilesToAttach = new[] { "file1" } })
 			{
-				File = _file.Object,
+				FileService = _file.Object,
 				Zipper = _zip.Object
 			};
 
@@ -59,7 +59,7 @@ namespace Tests.ExceptionReporting
 
 			var attacher = new Attacher(new ExceptionReportInfo { FilesToAttach = new[] { "file1", "file2", "file3" } })
 			{
-				File = _file.Object,
+				FileService = _file.Object,
 				Zipper = _zip.Object
 			};
 
@@ -76,7 +76,7 @@ namespace Tests.ExceptionReporting
 
 			var attacher = new Attacher(new ExceptionReportInfo { FilesToAttach = new[] { "file1", "file2", "file3" } })
 			{
-				File = _file.Object,
+				FileService = _file.Object,
 				Zipper = _zip.Object
 			};
 
@@ -91,7 +91,7 @@ namespace Tests.ExceptionReporting
 			_file.Setup(f => f.Exists(It.IsAny<string>())).Returns(true);
 			var attacher = new Attacher(new ExceptionReportInfo { FilesToAttach = new[] { "file1.zip", "file2.zip" } })
 			{
-				File = _file.Object,
+				FileService = _file.Object,
 				Zipper = _zip.Object
 			};
 
@@ -109,7 +109,7 @@ namespace Tests.ExceptionReporting
 
 			var attacher = new Attacher(new ExceptionReportInfo { FilesToAttach = new[] { "file1.zip" , "file2.txt"} })
 			{
-				File = _file.Object,
+				FileService = _file.Object,
 				Zipper = _zip.Object
 			};
 

--- a/src/Tests/ExceptionReporter_ManualTests.cs
+++ b/src/Tests/ExceptionReporter_ManualTests.cs
@@ -14,12 +14,15 @@ namespace Tests.ExceptionReporting
 	{
 		[Test]
 		[Ignore("UI")]
-		public static void ManualLocalizationTest()
+		[TestCase("en")]
+		[TestCase("ru")]
+
+		public static void ManualLocalizationTest(string languageTag)
 		{
 			var thread = new Thread(() =>
 			{
-			  Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("ru");
-			  Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfoByIetfLanguageTag("ru");
+			  Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag(languageTag);
+			  Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfoByIetfLanguageTag(languageTag);
 			  var er = new ExceptionReporter
 				{
 					Config =

--- a/src/Tests/ZipReportService_Tests.cs
+++ b/src/Tests/ZipReportService_Tests.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using System.Linq;
+using ExceptionReporting;
+using ExceptionReporting.Core;
+using ExceptionReporting.Mail;
+using Moq;
+using NUnit.Framework;
+
+namespace Tests.ExceptionReporting
+{
+	public class ZipReportService_Tests
+	{
+		//private Mock<IAttach> _iAttach;
+		private Mock<IScreenshotTaker> _screenshotTaker;
+		private Mock<IFileService> _fileService;
+		private Mock<IZipper> _zipper;
+
+		[SetUp]
+		public void SetUp()
+		{
+			//_iAttach = new Mock<IAttach>();
+			_screenshotTaker = new Mock<IScreenshotTaker>();
+			_fileService = new Mock<IFileService>();
+			_zipper = new Mock<IZipper>();
+		}
+
+		[Test]
+		public void None_Files_To_Add_To_Archive_ReturnsEmptyString()
+		{
+			var zipFilename = "Test.zip";
+			_fileService.Setup(f => f.TempFile(zipFilename)).Returns(zipFilename);
+			_zipper.Setup(z => z.Zip(zipFilename, It.IsAny<IEnumerable<string>>()));
+
+			var filesToAttach = new List<string>();
+			var config = new ExceptionReportInfo()
+				{ FilesToAttach = filesToAttach.ToArray(), TakeScreenshot = false, AttachmentFilename = zipFilename };
+			var zipReportService = new ZipReportService(_zipper.Object, _screenshotTaker.Object, _fileService.Object);
+
+			var result = zipReportService.CreateZipReport(config);
+
+			Assert.IsTrue(result == string.Empty);
+			_zipper.Verify(z => z.Zip(zipFilename, It.IsAny<IEnumerable<string>>()), Times.Never);
+			Mock.Verify();
+		}
+
+
+		[Test]
+		public void Two_Files_But_None_Exists_ReturnsEmptyString()
+		{
+			var logFile1 = "file1.log";
+			var logFile2 = "file2.log";
+			var zipFilename = "Test.zip";
+			_fileService.Setup(f => f.Exists(logFile1)).Returns(false);
+			_fileService.Setup(f => f.Exists(logFile2)).Returns(false);
+			_fileService.Setup(f => f.Exists(zipFilename)).Returns(true);
+			_fileService.Setup(f => f.TempFile(zipFilename)).Returns(zipFilename);
+			_zipper.Setup(z => z.Zip(zipFilename, It.IsAny<IEnumerable<string>>()));
+
+			var filesToAttach = new List<string>() { logFile1, logFile2 };
+			var config = new ExceptionReportInfo()
+				{ FilesToAttach = filesToAttach.ToArray(), TakeScreenshot = false, AttachmentFilename = zipFilename };
+			var zipReportService = new ZipReportService(_zipper.Object, _screenshotTaker.Object, _fileService.Object);
+
+			var result = zipReportService.CreateZipReport(config);
+
+			Assert.IsTrue(result == string.Empty);
+			_zipper.Verify(z => z.Zip(zipFilename, It.IsAny<IEnumerable<string>>()), Times.Never);
+			Mock.Verify();
+		}
+
+		[Test]
+		public void One_File_To_Add_To_Archive_ReturnsArchiveWithOneFile()
+		{
+			var logFile = "file1.log";
+			var zipFilename = "Test.zip";
+			_fileService.Setup(f => f.Exists(logFile)).Returns(true);
+			_fileService.Setup(f => f.Exists(zipFilename)).Returns(true);
+			_fileService.Setup(f => f.TempFile(zipFilename)).Returns(zipFilename);
+
+			var filesToAttach = new List<string>() {logFile};
+			var config = new ExceptionReportInfo()
+				{FilesToAttach = filesToAttach.ToArray(), TakeScreenshot = false, AttachmentFilename = zipFilename};
+			var zipReportService = new ZipReportService(_zipper.Object, _screenshotTaker.Object, _fileService.Object);
+
+			var result = zipReportService.CreateZipReport(config);
+
+			Assert.IsTrue(result == zipFilename);
+			_zipper.Verify(z => z.Zip(zipFilename, It.Is<IEnumerable<string>>(en => en.Count() == 1)), Times.AtLeastOnce);
+			Mock.Verify();
+		}
+		[Test]
+		public void Only_Screenshot_To_Add_To_Archive_ReturnsArchiveWithOneFile()
+		{
+			var zipFilename = "Test.zip";
+			var screenshotFilename = "Screenshot.jpg";
+			_screenshotTaker.Setup(s => s.TakeScreenShot()).Returns(screenshotFilename);
+			_fileService.Setup(f => f.Exists(screenshotFilename)).Returns(true);
+			_fileService.Setup(f => f.Exists(zipFilename)).Returns(true);
+			_fileService.Setup(f => f.TempFile(zipFilename)).Returns(zipFilename);
+			_zipper.Setup(z => z.Zip(zipFilename, It.Is<IEnumerable<string>>(en => en.Count() == 1)));
+
+			var filesToAttach = new List<string>();// { logFile };
+			var config = new ExceptionReportInfo()
+				{ FilesToAttach = filesToAttach.ToArray(), TakeScreenshot = true, AttachmentFilename = zipFilename };
+			var zipReportService = new ZipReportService(_zipper.Object, _screenshotTaker.Object, _fileService.Object);
+
+			var result = zipReportService.CreateZipReport(config);
+
+			Assert.IsTrue(result == zipFilename);
+			_zipper.Verify(z => z.Zip(zipFilename, It.Is<IEnumerable<string>>(en => en.Count() == 1)), Times.AtLeastOnce);
+			Mock.Verify();
+		}
+
+	[Test]
+	public void Two_Files_To_Add_To_Archive_ReturnsArchiveWithTwoFiles()
+	{
+		var logFile1 = "file1.log";
+		var logFile2 = "file2.log";
+		var zipFilename = "Test.zip";
+		_fileService.Setup(f => f.Exists(logFile1)).Returns(true);
+		_fileService.Setup(f => f.Exists(logFile2)).Returns(true);
+		_fileService.Setup(f => f.Exists(zipFilename)).Returns(true);
+		_fileService.Setup(f => f.TempFile(zipFilename)).Returns(zipFilename);
+
+		var filesToAttach = new List<string>() { logFile1, logFile2 };
+		var config = new ExceptionReportInfo()
+			{ FilesToAttach = filesToAttach.ToArray(), TakeScreenshot = false, AttachmentFilename = zipFilename };
+		var zipReportService = new ZipReportService(_zipper.Object, _screenshotTaker.Object, _fileService.Object);
+
+		var result = zipReportService.CreateZipReport(config);
+
+		Assert.IsTrue(result == zipFilename);
+		_zipper.Verify(z => z.Zip(zipFilename, It.Is<IEnumerable<string>>(en => en.Count() == 2)), Times.AtLeastOnce);
+		Mock.Verify();
+		}
+
+	[Test]
+	public void Take_Screenshot_True_MakesScreenshot()
+	{
+		var zipFilename = "Test.zip";
+		var screenshotFilename = "Screenshot.jpg";
+		_screenshotTaker.Setup(s => s.TakeScreenShot()).Returns(screenshotFilename);
+		_fileService.Setup(f => f.Exists(screenshotFilename)).Returns(true);
+		_fileService.Setup(f => f.TempFile(zipFilename)).Returns(zipFilename);
+
+		var config = new ExceptionReportInfo()
+			{TakeScreenshot = true, AttachmentFilename = zipFilename};
+		var zipReportService = new ZipReportService(_zipper.Object, _screenshotTaker.Object, _fileService.Object);
+		zipReportService.CreateZipReport(config);
+
+		_screenshotTaker.Verify(s => s.TakeScreenShot(), Times.Once());
+		Mock.Verify();
+	}
+
+	[Test]
+	public void Take_Screenshot_False_DoesNotMakeScreenshot()
+	{
+		var zipFilename = "Test.zip";
+		var screenshotFilename = "Screenshot.jpg";
+		_screenshotTaker.Setup(s => s.TakeScreenShot()).Returns(screenshotFilename);
+		_fileService.Setup(f => f.Exists(screenshotFilename)).Returns(true);
+		_fileService.Setup(f => f.TempFile(zipFilename)).Returns(zipFilename);
+
+		var config = new ExceptionReportInfo()
+			{ TakeScreenshot = false, AttachmentFilename = zipFilename };
+		var zipReportService = new ZipReportService(_zipper.Object, _screenshotTaker.Object, _fileService.Object);
+		zipReportService.CreateZipReport(config);
+
+		_screenshotTaker.Verify(s => s.TakeScreenShot(), Times.Never());
+		Mock.Verify();
+	}
+  }
+}


### PR DESCRIPTION
#53 click on **Save button** save the **zip file**, which contains **FilesToAttach**, **screenshot** and **report.txt**
![Save Button](https://user-images.githubusercontent.com/24358142/99889531-32c5a780-2c67-11eb-9966-d8458b48ac19.png "Save Button")

- added **ZipReportService.cs** which makes zip file with *FilesToAttach*, *screenshot* and optional *additionalFilesToAttach* (for example, *report.txt*)
- added Unit Tests for **ZipReportService.cs**