### PR TITLE
net5.0-windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ packages/
 .vscode
 *.orig
 MigrationBackup
+/src/ExceptionReporter.WinForms/Properties/PublishProfiles/FolderProfile.pubxml

--- a/src/ExceptionReporter.Shared/ReportGenerator.cs
+++ b/src/ExceptionReporter.Shared/ReportGenerator.cs
@@ -4,6 +4,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NETFRAMEWORK
+using System.Deployment.Application;
+#endif
 using System.Reflection;
 using ExceptionReporting.Core;
 using ExceptionReporting.Report;
@@ -41,16 +44,18 @@ namespace ExceptionReporting
 			_info.AppName = _info.AppName.IsEmpty() ? _info.AppAssembly.GetName().Name: _info.AppName;
 			_info.AppVersion = _info.AppVersion.IsEmpty() ? GetAppVersion() : _info.AppVersion;
 			_info.ExceptionDate = _info.ExceptionDateKind != DateTimeKind.Local ? DateTime.UtcNow : DateTime.Now;
-		}
+	}
 
 		private string GetAppVersion()
 		{
+#if NETFRAMEWORK
+			return ApplicationDeployment.IsNetworkDeployed ?
+				ApplicationDeployment.CurrentDeployment.CurrentVersion.ToString() : _info.AppAssembly.GetName().Version.ToString();
+#else
 			return _info.AppAssembly.GetName().Version.ToString();
-			// lost during migration to net5.0
-			//return ApplicationDeployment.IsNetworkDeployed ? 
-			//	ApplicationDeployment.CurrentDeployment.CurrentVersion.ToString() : _info.AppAssembly.GetName().Version.ToString();
+#endif
 		}
-		
+
 		/// <summary>
 		/// Generate the exception report
 		/// </summary>

--- a/src/ExceptionReporter.Shared/ReportGenerator.cs
+++ b/src/ExceptionReporter.Shared/ReportGenerator.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Deployment.Application;
 using System.Reflection;
 using ExceptionReporting.Core;
 using ExceptionReporting.Report;
@@ -46,8 +45,10 @@ namespace ExceptionReporting
 
 		private string GetAppVersion()
 		{
-			return ApplicationDeployment.IsNetworkDeployed ? 
-				ApplicationDeployment.CurrentDeployment.CurrentVersion.ToString() : _info.AppAssembly.GetName().Version.ToString();
+			return _info.AppAssembly.GetName().Version.ToString();
+			// lost during migration to net5.0
+			//return ApplicationDeployment.IsNetworkDeployed ? 
+			//	ApplicationDeployment.CurrentDeployment.CurrentVersion.ToString() : _info.AppAssembly.GetName().Version.ToString();
 		}
 		
 		/// <summary>

--- a/src/ExceptionReporter.WinForms/ExceptionReporter.WinForms.csproj
+++ b/src/ExceptionReporter.WinForms/ExceptionReporter.WinForms.csproj
@@ -4,7 +4,8 @@
 		<AssemblyName>ExceptionReporter.NET</AssemblyName>
 		<PackageId>ExceptionReporter</PackageId>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<TargetFrameworks>net40</TargetFrameworks>
+		<TargetFrameworks>net40;net5.0-windows</TargetFrameworks>
+		<UseWindowsForms>true</UseWindowsForms>
 		<ReleaseVersion>5.0</ReleaseVersion>
 		<PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/PandaWood/ExceptionReporter.NET</PackageProjectUrl>
@@ -13,10 +14,17 @@
     <EmbeddedResource Remove="Properties\Resources.en.resx" />
     <EmbeddedResource Remove="Properties\Resources.ru.resx" />
   </ItemGroup>
-  <ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+		<PackageReference Include="Simple-MAPI.NET" Version="1.2.0" />
     <PackageReference Include="DotNetZip" Version="1.15.0" />
     <PackageReference Include="Handlebars.Net" Version="1.9.0" />
-    <PackageReference Include="Simple-MAPI.NET" Version="1.2.0" />
+	</ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0-windows' ">
+		<PackageReference Include="Simple-MAPI.NET" Version="1.2.1" />
+		<PackageReference Include="DotNetZip" Version="1.15.0" />
+		<PackageReference Include="Handlebars.Net" Version="2.0.9" />
+		<PackageReference Include="System.Management" Version="6.0.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
   </ItemGroup>
     <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.en.resx">
@@ -29,14 +37,10 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Deployment" />
-    <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
-    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <PropertyGroup>
-    <Version>5.0</Version>
+    <Version>5.0.1</Version>
     <FileVersion>5.0.0.0</FileVersion>
     <Authors>Peter van der Woude, Simon Cropp</Authors>
     <Description>ExceptionReporter is a .NET UserControl/Dialog that gathers detailed information on an Exception and the application/system running it. It allows the user to copy, save or email a report to the developer</Description>

--- a/src/ExceptionReporter.WinForms/ExceptionReporter.WinForms.csproj
+++ b/src/ExceptionReporter.WinForms/ExceptionReporter.WinForms.csproj
@@ -16,6 +16,7 @@
     <EmbeddedResource Remove="Properties\Resources.ru.resx" />
   </ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+		<Reference Include="System.Deployment" />
 		<PackageReference Include="Simple-MAPI.NET" Version="1.2.0" />
     <PackageReference Include="DotNetZip" Version="1.15.0" />
     <PackageReference Include="Handlebars.Net" Version="1.9.0" />
@@ -23,7 +24,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0-windows' ">
 		<PackageReference Include="Simple-MAPI.NET" Version="1.2.1" />
 		<PackageReference Include="DotNetZip" Version="1.15.0" />
-		<PackageReference Include="Handlebars.Net" Version="2.0.2" />
+		<PackageReference Include="Handlebars.Net" Version="2.0.10" />
 		<PackageReference Include="System.Management" Version="6.0.0" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
   </ItemGroup>

--- a/src/ExceptionReporter.WinForms/ExceptionReporter.WinForms.csproj
+++ b/src/ExceptionReporter.WinForms/ExceptionReporter.WinForms.csproj
@@ -6,6 +6,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<TargetFrameworks>net40;net5.0-windows</TargetFrameworks>
 		<UseWindowsForms>true</UseWindowsForms>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<ReleaseVersion>5.0</ReleaseVersion>
 		<PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/PandaWood/ExceptionReporter.NET</PackageProjectUrl>
@@ -22,7 +23,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0-windows' ">
 		<PackageReference Include="Simple-MAPI.NET" Version="1.2.1" />
 		<PackageReference Include="DotNetZip" Version="1.15.0" />
-		<PackageReference Include="Handlebars.Net" Version="2.0.9" />
+		<PackageReference Include="Handlebars.Net" Version="2.0.2" />
 		<PackageReference Include="System.Management" Version="6.0.0" />
     <PackageReference Include="System.Resources.Extensions" Version="6.0.0" />
   </ItemGroup>

--- a/src/Tests/AssemblyDigger_Tests.cs
+++ b/src/Tests/AssemblyDigger_Tests.cs
@@ -13,7 +13,9 @@ namespace Tests.ExceptionReporting
 			var digger = new AssemblyDigger(Assembly.Load("ExceptionReporter.NET"));
 			var refs = digger.GetAssemblyRefs().ToList();
 
-			Assert.That(refs.Select(r => r.Name), Is.SupersetOf(new [] {"System.Core", "DotNetZip", "SimpleMapi.NET"}));
+			//TODO: is "System.Core" necessesary here?
+			//Assert.That(refs.Select(r => r.Name), Is.SupersetOf(new [] {"System.Core", "DotNetZip", "SimpleMapi.NET"}));//
+			Assert.That(refs.Select(r => r.Name), Is.SupersetOf(new [] {"DotNetZip", "SimpleMapi.NET", "Handlebars" }));
 		}
 
 		[Test]

--- a/src/Tests/AssemblyDigger_Tests.cs
+++ b/src/Tests/AssemblyDigger_Tests.cs
@@ -13,8 +13,6 @@ namespace Tests.ExceptionReporting
 			var digger = new AssemblyDigger(Assembly.Load("ExceptionReporter.NET"));
 			var refs = digger.GetAssemblyRefs().ToList();
 
-			//TODO: is "System.Core" necessesary here?
-			//Assert.That(refs.Select(r => r.Name), Is.SupersetOf(new [] {"System.Core", "DotNetZip", "SimpleMapi.NET"}));//
 			Assert.That(refs.Select(r => r.Name), Is.SupersetOf(new [] {"DotNetZip", "SimpleMapi.NET", "Handlebars" }));
 		}
 

--- a/src/Tests/ReportBuilder_Tests.cs
+++ b/src/Tests/ReportBuilder_Tests.cs
@@ -1,6 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
+#if !NETCOREAPP
 using AutoMoq;
+#else
+using AutoMoqCore;
+#endif
 using ExceptionReporting;
 using ExceptionReporting.Report;
 using ExceptionReporting.SystemInfo;

--- a/src/Tests/Tests.ExceptionReporter.NET.csproj
+++ b/src/Tests/Tests.ExceptionReporter.NET.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
 		<RootNamespace>Tests.ExceptionReporting</RootNamespace>
 		<ReleaseVersion>4.0.3</ReleaseVersion>
 	</PropertyGroup>

--- a/src/Tests/Tests.ExceptionReporter.NET.csproj
+++ b/src/Tests/Tests.ExceptionReporter.NET.csproj
@@ -1,16 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFrameworks>net472;net5.0-windows</TargetFrameworks>
 		<RootNamespace>Tests.ExceptionReporting</RootNamespace>
 		<ReleaseVersion>4.0.3</ReleaseVersion>
 	</PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="AutoMoq" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+		<PackageReference Include="AutoMoq" Version="2.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="Moq" Version="4.16.1" />
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0-windows' ">
+		<PackageReference Include="System.Management" Version="6.0.0" />
+		<PackageReference Include="AutoMoqCore" Version="2.1.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+		<PackageReference Include="Moq" Version="4.16.1" />
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+	</ItemGroup>
   <ItemGroup>
 		<None Remove="packages.config" />
   </ItemGroup>
@@ -18,7 +26,6 @@
     <ProjectReference Include="..\ExceptionReporter.WinForms\ExceptionReporter.WinForms.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="System.Deployment" />
     <Reference Include="System.Management" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR will update the ExceptionReporter.NET to support the `net5.0-windows` TargetFramework

I have tested it manually and all seems OK.
Also, I have run UnitTests for `net5.0-windows` and 2 of them were red:
1.  - [x] `Can_Dig_Assembly_Refs_By_Name()` - I assume it was false negative. This test checked the existence of "System.Core" but it wasn't necessary(?) 
2.  - [ ] `Can_Render_Text_Template_Baseline_1_Of_Everything()` - the problem is in Handlebars 2.0.2. There are newer versions of Handlebars, but them had more bugs (more failed unit tests). Later I will report about it to the maintainers of Handlebars
___
- [ ] problem with the ApplicationDeployment API in Net5
